### PR TITLE
Add Makefile and update Makefile.uk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+UK_ROOT ?= $(PWD)/.unikraft/unikraft
+UK_LIBS ?= $(PWD)/.unikraft/libs
+
+LIBS := $(UK_LIBS)/compiler-rt:$(UK_LIBS)/libunwind:$(UK_LIBS)/libgo:$(UK_LIBS)/musl:$(UK_LIBS)/lwip
+
+all:
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)
+
+$(MAKECMDGOALS):
+	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS) $(MAKECMDGOALS)

--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,3 +1,3 @@
-$(eval $(call addlib,apphelloworldgo))
+$(eval $(call addgoapp,apphelloworldgo))
 
 APPHELLOWORLDGO_SRCS-y += $(APPHELLOWORLDGO_BASE)/helloworld.go


### PR DESCRIPTION
This PR is part of a series of PRs that work in conjunction for the update of Go support to 1.18:

- https://github.com/unikraft/lib-libgo/pull/7
- https://github.com/unikraft/unikraft/pull/1005
- https://github.com/unikraft/lib-musl/pull/67
- https://github.com/unikraft/app-helloworld-go/pull/9
- https://github.com/unikraft/lib-compiler-rt/pull/16
- https://github.com/unikraft/lib-musl/pull/52

For testing, make sure to pass to QEMU the `-cpu host` argument (this is necessary because the paging API and ukvmem are required by `libgo` as part of Virtual Address space management, and somehow the default CPU just won't handle 1GB pages).

Only GCC12 and x86 is supported for the moment.