### PR TITLE
Add KraftKit configuration file for KraftCloud

### DIFF
--- a/kraft.cloud.yaml
+++ b/kraft.cloud.yaml
@@ -1,0 +1,34 @@
+specification: '0.5'
+name: helloworld-go
+unikraft:
+  version: cloud
+  kconfig:
+    - CONFIG_LIBSYSCALL_SHIM_LIBCSTUBS=y
+    - CONFIG_LIBPOSIX_MMAP=y
+    - CONFIG_LIBUKSCHED=y
+    - CONFIG_LIBUKSCHEDCOOP=y
+    - CONFIG_STACK_SIZE_PAGE_ORDER=5
+targets:
+  - name: kraftcloud-x86_64
+    architecture: x86_64
+    platform: firecracker
+    kconfig:
+      - CONFIG_PLAT_KVM=y
+      - CONFIG_KVM_BOOT_PROTO_LXBOOT=y
+      - CONFIG_KVM_VMM_FIRECRACKER=y
+      - CONFIG_VIRTIO_BUS=y
+      - CONFIG_VIRTIO_NET=n
+libraries:
+  libgo:
+    version: stable
+  libunwind:
+    version: stable
+  compiler-rt:
+    version: stable
+  lwip:
+    version: stable
+  musl:
+    version: stable
+  ukp-bin:
+    source: https://github.com/unikraft-io/lib-ukp-bin
+    version: stable


### PR DESCRIPTION
Add `kraft.cloud.yaml` configuration file to build and run for KraftCloud.

Build with:

```console
kraft build --kraftfile kraft.cloud.yaml
```

Run with:

```console
sudo kraft net create -n 172.44.0.1/24 kraft0
sudo kraft run --kraftfile kraft.cloud.yaml --network bridge:kraft0 --plat firecracker -a netdev.ipv4_addr=172.44.0.2 -a netdev.ipv4_gw_addr=172.44.0.1 -a netdev.ipv4_subnet_mask=255.255.255.0 -- helloworld
```