### PR TITLE
Add networking support for Go applications

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,3 +1,4 @@
 $(eval $(call addgoapp,apphelloworldgo))
 
 APPHELLOWORLDGO_SRCS-y += $(APPHELLOWORLDGO_BASE)/helloworld.go
+#APPHELLOWORLDGO_SRCS-y += $(APPHELLOWORLDGO_BASE)/server.go

--- a/kraft.cloud.yaml
+++ b/kraft.cloud.yaml
@@ -17,7 +17,6 @@ targets:
       - CONFIG_KVM_BOOT_PROTO_LXBOOT=y
       - CONFIG_KVM_VMM_FIRECRACKER=y
       - CONFIG_VIRTIO_BUS=y
-      - CONFIG_VIRTIO_NET=n
 libraries:
   libgo:
     version: stable

--- a/server.go
+++ b/server.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func hello(w http.ResponseWriter, req *http.Request) {
+
+	fmt.Fprintf(w, "hello\n")
+}
+
+func headers(w http.ResponseWriter, req *http.Request) {
+
+	for name, headers := range req.Header {
+		for _, h := range headers {
+			fmt.Fprintf(w, "%v: %v\n", name, h)
+		}
+	}
+}
+
+func main() {
+
+	http.HandleFunc("/hello", hello)
+	http.HandleFunc("/headers", headers)
+
+	http.ListenAndServe(":8090", nil)
+}


### PR DESCRIPTION
Add networking support for Go applications. Demonstrate using `server.go`, a simple HTTP-like server written in Go.

To build `server.go`, first uncomment the `server.go` line in `Makefile.uk`, and comment out the `helloworld.go` line.

Then, build the Unikraft image:
    
```console
kraft build --kraftfile kraft.cloud.yaml
```
    
Run the Unikraft Go server image:
    
```console
sudo kraft net rm kraft0
sudo kraft net create -n 172.44.0.1/24 kraft0
sudo kraft run --kraftfile kraft.cloud.yaml --plat firecracker --network bridge:kraft0 -M 256M -a netdev.ipv4_addr=172.44.0.2 -a netdev.ipv4_gw_addr=172.44.0.1 -a netdev.ipv4_subnet_mask=255.255.255.0 -- "server"
```